### PR TITLE
Remove flake8-docstrings from Travis CI Config.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ install:
 - pip install freezegun
 - pip install mock
 - pip install opentracing
-- pip install git+https://github.com/wavefrontHQ/wavefront-python-sdk.git
+- pip install wavefront-sdk-python
 - pip install wavefront-pyformance
 - pip install flake8 flake8-colors flake8-import-order
 - pip install pep8-naming

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ install:
 - pip install opentracing
 - pip install git+https://github.com/wavefrontHQ/wavefront-python-sdk.git
 - pip install wavefront-pyformance
-- pip install flake8 flake8-colors flake8-docstrings flake8-import-order
+- pip install flake8 flake8-colors flake8-import-order
 - pip install pep8-naming
 - pip install pylint
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,12 @@ install:
 - pip install wavefront-pyformance
 - pip install flake8 flake8-colors flake8-import-order
 - pip install pep8-naming
+- pip install pydocstyle
 - pip install pylint
 before_script:
 - python -m flake8
 - python -m pylint wavefront_opentracing_sdk
+- python -m pydocstyle
 script:
 - python -m unittest discover
 - if [[ "${TRAVIS_PULL_REQUEST}" != "false" ]]; then
@@ -37,3 +39,4 @@ deploy:
   on:
     python: 3.7
     tags: true
+

--- a/open_source_license.txt
+++ b/open_source_license.txt
@@ -1,6 +1,6 @@
 open_source_license.txt
 
-Wavefront by VMware OpenTracing SDK for Python 1.1 GA
+Wavefront by VMware OpenTracing SDK for Python 1.2 GA
 
 ======================================================================
 
@@ -335,4 +335,4 @@ Source Files is valid for three years from the date you acquired or last used th
 Software product. Alternatively, the Source Files may accompany the
 VMware service.
 
-[WAVEFRONTOPENTRACINGSDKPYTHON11GANT032619]
+[WAVEFRONTOPENTRACINGSDKPYTHON12GANT070819]

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ with open(os.path.join(os.path.abspath(os.path.dirname(__file__)),
 
 setuptools.setup(
     name='wavefront-opentracing-sdk-python',
-    version='1.1.3',
+    version='1.2',
     author='Wavefront by VMware',
     author_email='chitimba@wavefront.com',
     url='https://github.com/wavefrontHQ/wavefront-opentracing-sdk-python',
@@ -43,7 +43,7 @@ setuptools.setup(
     install_requires=[
         'opentracing>=2.0',
         'wavefront-pyformance>=1.0',
-        'wavefront-sdk-python>=1.1',
+        'wavefront-sdk-python>=1.2',
         ],
     test_require=[
         'freezegun>=0.3.11',

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ with open(os.path.join(os.path.abspath(os.path.dirname(__file__)),
 
 setuptools.setup(
     name='wavefront-opentracing-sdk-python',
-    version='1.1.2',
+    version='1.1.3',
     author='Wavefront by VMware',
     author_email='chitimba@wavefront.com',
     url='https://github.com/wavefrontHQ/wavefront-opentracing-sdk-python',


### PR DESCRIPTION
flake8-docstrings plugin fails with latest flake8

```python -m flake8
"flake8-docstrings" failed during execution due to "module 'pydocstyle' has no attribute 'tokenize_open'"
Run flake8 with greater verbosity to see more details```