### PR TITLE
Fix SpanLog not reporting

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ with open(os.path.join(os.path.abspath(os.path.dirname(__file__)),
 
 setuptools.setup(
     name='wavefront-opentracing-sdk-python',
-    version='1.2.1',
+    version='1.2.2',
     author='Wavefront by VMware',
     author_email='chitimba@wavefront.com',
     url='https://github.com/wavefrontHQ/wavefront-opentracing-sdk-python',

--- a/test/test_wavefront_span.py
+++ b/test/test_wavefront_span.py
@@ -253,7 +253,7 @@ class TestSpan(unittest.TestCase):
                      ('cluster', 'us-west-1'),
                      ('shard', 'primary'),
                      ('custom_k', 'custom_v')],
-                span_logs=None),
+                span_logs=[]),
             mock.call.send_metric(
                 name='tracing.derived.app.service.{}.invocation.'
                      'count'.format(operation_name),

--- a/test/test_wavefront_span.py
+++ b/test/test_wavefront_span.py
@@ -181,7 +181,7 @@ class TestSpan(unittest.TestCase):
                      ('cluster', 'us-west-1'),
                      ('shard', 'primary'),
                      ('custom_k', 'custom_v')],
-                span_logs=None),
+                span_logs=[]),
             mock.call.send_metric(
                 name='tracing.derived.new_app.service.{}.invocation.'
                      'count'.format(operation_name),

--- a/wavefront_opentracing_sdk/reporting/wavefront.py
+++ b/wavefront_opentracing_sdk/reporting/wavefront.py
@@ -71,7 +71,7 @@ class WavefrontSpanReporter(reporter.Reporter):
                 int(wavefront_span.get_duration_time() * 1000), self.source,
                 wavefront_span.trace_id, wavefront_span.span_id,
                 wavefront_span.get_parents(), wavefront_span.get_follows(),
-                wavefront_span.get_tags(), span_logs=None)
+                wavefront_span.get_tags(), span_logs=wavefront_span.get_logs())
         except (AttributeError, TypeError):
             if self.report_errors:
                 self.report_errors.inc()


### PR DESCRIPTION
Fixed Spanlog incorrectly set to `None` in #21 :
https://github.com/wavefrontHQ/wavefront-opentracing-sdk-python/pull/21/files#diff-4b1256743d0e7097b26e13b91d08909eR74