### PR TITLE
Promote http status to heartbeat and error metrics

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ with open(os.path.join(os.path.abspath(os.path.dirname(__file__)),
 
 setuptools.setup(
     name='wavefront-opentracing-sdk-python',
-    version='1.2.9',
+    version='1.2.10',
     author='Wavefront by VMware',
     author_email='chitimba@wavefront.com',
     url='https://github.com/wavefrontHQ/wavefront-opentracing-sdk-python',


### PR DESCRIPTION
This PR will:
1. Promote `http.status_code` tag to custom heartbeat and Error metrics.
2. Remove `operation` tag from custom heartbeat.

Notes on different set of tags:
| Category                    | Tags                                                                                                            |
|-----------------------------|-----------------------------------------------------------------------------------------------------------------|
| Custom heartbeat            | application, service, cluster, shard, span kind/other custom tags, http status (if error)                       |
| Error metric                | application, service, cluster, shard, span kind/other custom tags, operation, http status (if error) |
| Request and Duration metric | application, service, cluster, shard, span kind/other custom tags, operation                         |
| Duration histogram          | application, service, cluster, shard, span kind/other custom tags, operation, error boolean          |