### PR TITLE
Utilize user-defined 'component' tag value (if any) for new spans

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ with open(os.path.join(os.path.abspath(os.path.dirname(__file__)),
 
 setuptools.setup(
     name='wavefront-opentracing-sdk-python',
-    version='2.2.2',
+    version='2.2.3',
     author='Wavefront by VMware',
     author_email='chitimba@wavefront.com',
     url='https://github.com/wavefrontHQ/wavefront-opentracing-sdk-python',

--- a/test/test_wavefront_span.py
+++ b/test/test_wavefront_span.py
@@ -8,7 +8,6 @@ import unittest
 import uuid
 
 import freezegun
-
 import opentracing.ext.tags
 from opentracing.tags import HTTP_STATUS_CODE
 
@@ -78,6 +77,7 @@ class TestSpan(unittest.TestCase):
         self.assertTrue('custom_v' in span.get_tags_as_map().get('custom_k'))
         self.assertTrue('val1' in span.get_tags_as_map().get('key1'))
         self.assertTrue('val2' in span.get_tags_as_map().get('key1'))
+        self.assertEqual(['none'], span.get_tags_as_map().get('component'))
         span.finish()
         tracer.close()
 
@@ -97,6 +97,20 @@ class TestSpan(unittest.TestCase):
         self.assertTrue('primary' in span.get_tags_as_map().get('shard'))
         self.assertTrue('custom_v' in span.get_tags_as_map().get('custom_k'))
         self.assertTrue('val1' in span.get_tags_as_map().get('key1'))
+        self.assertEqual(['none'], span.get_tags_as_map().get('component'))
+        span.finish()
+        tracer.close()
+
+    def test_tags_with_components_defined(self):
+        """Test Multi-valued Tags."""
+        tracer = WavefrontTracer(ConsoleReporter(), self.application_tags)
+        span = tracer.start_span('test_op', tags={'component': 'my_component'})
+        self.assertIsNotNone(span)
+        self.assertIsNotNone(span.get_tags())
+        self.assertIsNotNone(span.get_tags_as_list())
+        self.assertIsNotNone(span.get_tags_as_map())
+        self.assertEqual(6, len(span.get_tags_as_map()))
+        self.assertEqual(['my_component'], span.get_tags_as_map().get('component'))
         span.finish()
         tracer.close()
 

--- a/wavefront_opentracing_sdk/span.py
+++ b/wavefront_opentracing_sdk/span.py
@@ -54,7 +54,7 @@ class WavefrontSpan(opentracing.Span):
         for tag in tags:
             if isinstance(tag, tuple):
                 self.set_tag(tag[0], tag[1])
-        if opentracing.ext.tags.COMPONENT not in self.tags:
+        if opentracing.ext.tags.COMPONENT not in dict(self.tags):
             self.set_tag(opentracing.ext.tags.COMPONENT, "none")
         self._spans_discarded = None if tracer.wf_internal_reporter is None \
             else tracer.wf_internal_reporter.registry.\


### PR DESCRIPTION
Use the user-defined 'component' span tag (if defined) for new spans.
Fixes #56